### PR TITLE
correcciones switch case y className

### DIFF
--- a/ohana-app/app/containers/GTree/NodeDetail.js
+++ b/ohana-app/app/containers/GTree/NodeDetail.js
@@ -41,46 +41,7 @@ class NodeDetail extends Component {
 
   handleColorChange(color, event) {
     const fill = color.hex;
-    switch (fill) {
-      case '#f44336':
-        return this.props.onColorChange('#f44336');
-      case '#e91e63':
-        return this.props.onColorChange('#e91e63');
-      case '#9c27b0':
-        return this.props.onColorChange('#9c27b0');
-      case '#673ab7':
-        return this.props.onColorChange('#673ab7');
-      case '#3f51b5':
-        return this.props.onColorChange('#3f51b5');
-      case '#2196f3':
-        return this.props.onColorChange('#2196f3');
-      case '#03a9f4':
-        return this.props.onColorChange('#03a9f4');
-      case '#00bcd4':
-        return this.props.onColorChange('#00bcd4');
-      case '#009688':
-        return this.props.onColorChange('#009688');
-      case '#4caf50':
-        return this.props.onColorChange('#4caf50');
-      case '#8bc34a':
-        return this.props.onColorChange('#8bc34a');
-      case '#cddc39':
-        return this.props.onColorChange('#cddc39');
-      case '#ffeb3b':
-        return this.props.onColorChange('#ffeb3b');
-      case '#ffc107':
-        return this.props.onColorChange('#ffc107');
-      case '#ff9800':
-        return this.props.onColorChange('#ff9800');
-      case '#ff5722':
-        return this.props.onColorChange('#ff5722');
-      case '#795548':
-        return this.props.onColorChange('#795548');
-      case '#607d8b':
-        return this.props.onColorChange('#607d8b');
-      default:
-        return 'transparent';
-    }
+    return this.props.onColorChange(fill);
   }
 
   setStartDate(date) {
@@ -93,7 +54,7 @@ class NodeDetail extends Component {
     return (
       <div>
         <Input
-          className="element-panel"
+          {/*className="element-panel"*/}
           placeholder="Basic usage"
           type="text"
           value={this.props.actualNode.n}
@@ -103,7 +64,7 @@ class NodeDetail extends Component {
         <Select
           onChange={this.handleSexChange}
           defaultValue={this.props.actualNode.s}
-          className="element-panel"
+          {/*className="element-panel"*/}
         >
           <Option key="M" value="M">
             Male
@@ -114,14 +75,14 @@ class NodeDetail extends Component {
         </Select>
 
         <DatePicker
-          className="element-panel"
+          {/*className="element-panel"*/}
           selected={this.setStartDate(this.props.actualNode.date)}
           onChange={this.handleDateChange}
         />
 
         <div id="color-content">
           <CirclePicker
-            className="element-panel"
+            {/*className="element-panel"*/}
             onChange={this.handleColorChange}
           />
         </div>


### PR DESCRIPTION
switch case innecesario, y componentes de react no deberían tener className, es mejor pone el className dentro de cada componente (a menos de que sea de librería)